### PR TITLE
Add Perl package manager

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,3 @@
 requires 'Fuse', '0.12.0';
-requires 'POSIX', '1.09';
 requires 'WWW::Curl::Easy', '4.17';
 requires 'JSON', '2.92';

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,4 @@
+requires 'Fuse', '0.12.0';
+requires 'POSIX', '1.09';
+requires 'WWW::Curl::Easy', '4.17';
+requires 'JSON', '2.92';


### PR DESCRIPTION
Added Perl's `cpanfile` package manager with packages dating back to Perl's last edit date of July 20, 2018.